### PR TITLE
Remove additional border around light card

### DIFF
--- a/themes/light-soft-ui.yaml
+++ b/themes/light-soft-ui.yaml
@@ -127,7 +127,7 @@ Light Soft UI:
       }
       ha-card > #states,
       ha-card > .header-footer,
-      ha-card:not(.type-humidifier) > .content {
+      ha-card:not(.type-humidifier):not(.type-light) > .content {
         box-shadow: -8px -8px 8px 0 rgba(255,255,255,.5),8px 8px 8px 0 rgba(0,0,0,.03);
         border-radius: var(--ha-card-border-radius);
         margin: 12px;


### PR DESCRIPTION
Adding this fixes a double border forming around a lovelace light card.
See the before and after:
https://imgur.com/a/g3mz5ta